### PR TITLE
OpenAI URL 兼容性提升

### DIFF
--- a/CAPTCHA-automatic-recognition/src/app.vue
+++ b/CAPTCHA-automatic-recognition/src/app.vue
@@ -957,6 +957,13 @@ export default {
         return "https://api.openai.com/v1/chat/completions";
       }
 
+      if (url.endsWith("#")) {
+        return url.slice(0, -1);
+      }
+      if (url.endsWith("/chat/completions")) {
+        return url;
+      }
+
       if (!url.endsWith("/v1/chat/completions")) {
         // 移除末尾的斜杠（如果有）
         url = url.replace(/\/+$/, "");


### PR DESCRIPTION
增加对智谱API的支持，以便使用GLM-4.6V-Flash免费模型。
现有逻辑只判断/v1/chat/completions，会在智谱API URL [https://open.bigmodel.cn/api/paas/v4/chat/completions] 后再追加/v1/chat/completions，导致无法使用。
另外，额外增加#号结尾的URL不做任何追加的逻辑。